### PR TITLE
Fix StoryArc fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [Python](https://www.python.org/) wrapper for the [Comicvine](https://comicvin
 
 ## Installation
 
-### PyPI
+### Pip
 
 ```bash
 $ pip3 install -U --user simyan
@@ -42,7 +42,7 @@ session = Comicvine(api_key="ComicVine API Key", cache=SQLiteCache())
 # Search for Publisher
 results = session.publisher_list(params={"filter": "name:DC Comics"})
 for publisher in results:
-    print(f"{publisher.id_} | {publisher.name} - {publisher.site_url}")
+    print(f"{publisher.publisher_id} | {publisher.name} - {publisher.site_url}")
 
 # Get details for a Volume
 result = session.volume(volume_id=26266)

--- a/docs/source/about.rst.inc
+++ b/docs/source/about.rst.inc
@@ -10,7 +10,7 @@
     # Search for Publisher
     results = session.publisher_list(params={'filter': 'name:DC Comics'})
     for publisher in results:
-        print(f"{publisher.id_} | {publisher.name} - {publisher.site_url}")
+        print(f"{publisher.publisher_id} | {publisher.name} - {publisher.site_url}")
 
     # Get details for a Volume
     result = session.volume(volume_id=26266)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,4 +12,10 @@ To install the latest stable version from the PyPI:
 
 ::
 
-    $ pip3 install -U --user Simyan
+    $ pip3 install -U --user simyan
+
+or via poetry:
+
+::
+
+    $ poetry install simyan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Simyan"
-version = "0.9.1"
+version = "0.9.2"
 description = "A Python wrapper for the Comicvine API."
 license = "GPL-3.0-or-later"
 authors = ["Buried-In-Code <BuriedInCode@tuta.io>"]

--- a/simyan/__init__.py
+++ b/simyan/__init__.py
@@ -1,5 +1,5 @@
 """simyan package entry file."""
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 __all__ = ["__version__", "get_cache_root"]
 
 from pathlib import Path

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -113,11 +113,13 @@ class Comicvine:
                 raise AuthenticationError("Invalid API Key")
             elif err.response.status_code == 404:
                 raise ServiceError("Unknown endpoint")
+            elif err.response.status_code == 502:
+                raise ServiceError("Service error, retry again in 30s")
             raise ServiceError(err.response.json()["error"])
         except JSONDecodeError:
             raise ServiceError(f"Unable to parse response from `{url}` as Json")
         except ReadTimeout:
-            raise ServiceError("Server took too long to respond")
+            raise ServiceError("Service took too long to respond")
 
     def _get_request(
         self, endpoint: str, params: Dict[str, str] = None, skip_cache: bool = False

--- a/simyan/schemas/story_arc.py
+++ b/simyan/schemas/story_arc.py
@@ -24,8 +24,8 @@ class StoryArc(BaseModel):
     date_added: datetime  #: Date and time when the Story Arc was added to Comicvine.
     date_last_updated: datetime  #: Date and time when the Story Arc was updated on Comicvine.
     description: Optional[str] = Field(default=None)  #: Long description of the Story Arc.
-    first_issue: IssueEntry = Field(
-        alias="first_appeared_in_issue"
+    first_issue: Optional[IssueEntry] = Field(
+        default=None, alias="first_appeared_in_issue"
     )  #: First issue of the Story Arc.
     id_: int = Field(alias="id")  #: Identifier used in Comicvine.
     story_arc_id: int = Field(alias="id")  #: Identifier used in Comicvine.
@@ -35,7 +35,7 @@ class StoryArc(BaseModel):
     )  #: Number of issues in the Story Arc.
     issues: List[GenericEntry] = Field(default_factory=list)  #: List of issues in the Story Arc.
     name: str  #: Name/Title of the Story Arc.
-    publisher: GenericEntry  #: The publisher of the Story Arc.
+    publisher: Optional[GenericEntry] = None  #: The publisher of the Story Arc.
     site_url: str = Field(alias="site_detail_url")  #: Url to the Comicvine Website.
     summary: Optional[str] = Field(
         default=None, alias="deck"

--- a/tests/test_story_arcs.py
+++ b/tests/test_story_arcs.py
@@ -35,11 +35,23 @@ def test_story_arc_fail(session: Comicvine):
         session.story_arc(story_arc_id=-1)
 
 
+def test_story_arc_null_first_issue(session: Comicvine):
+    """Test story_arc endpoint to return result with no first_issue."""
+    result = session.story_arc(story_arc_id=56273)
+    assert result.first_issue is None
+
+
+def test_story_arc_null_publisher(session: Comicvine):
+    """Test story_arc endpoint to return result with no publisher."""
+    result = session.story_arc(story_arc_id=56765)
+    assert result.publisher is None
+
+
 def test_story_arc_list(session: Comicvine):
     """Test using the story_arc_list endpoint with a valid search."""
-    search_results = session.story_arc_list({"filter": "name:Blackest Night"})
-    assert len(search_results) != 0
-    result = [x for x in search_results if x.story_arc_id == 55766][0]
+    results = session.story_arc_list({"filter": "name:Blackest Night"})
+    assert len(results) != 0
+    result = [x for x in results if x.story_arc_id == 55766][0]
     assert result is not None
 
     assert result.alias_list == []
@@ -63,6 +75,24 @@ def test_story_arc_list_max_results(session: Comicvine):
     """Test story_arc_list endpoint with max_results."""
     results = session.story_arc_list({"filter": "name:Night"}, max_results=10)
     assert len(results) == 10
+
+
+def test_story_arc_list_null_first_issue(session: Comicvine):
+    """Test story_arc_list endpoint to return result with no first_issue."""
+    results = session.story_arc_list({"filter": "name:Lo, this Monster"})
+    assert len(results) != 0
+    result = [x for x in results if x.story_arc_id == 56273][0]
+    assert result is not None
+    assert result.first_issue is None
+
+
+def test_story_arc_list_null_publisher(session: Comicvine):
+    """Test story_arc_list endpoint to return result with no publisher."""
+    results = session.story_arc_list({"filter": "name:Lo, this Monster"})
+    assert len(results) != 0
+    result = [x for x in results if x.story_arc_id == 56765][0]
+    assert result is not None
+    assert result.publisher is None
 
 
 def test_search_story_arc(session: Comicvine):


### PR DESCRIPTION
 - Mark `StoryArc.publisher` as an Optional field _#118_
 - Mark `StoryArc.first_issue` as an Optional field
 - Minor documentation tweaks