### PR TITLE
Split schemas

### DIFF
--- a/docs/simyan/schemas/character.md
+++ b/docs/simyan/schemas/character.md
@@ -1,3 +1,4 @@
 # Character
 
 ::: simyan.schemas.character.Character
+::: simyan.schemas.character.CharacterEntry

--- a/docs/simyan/schemas/creator.md
+++ b/docs/simyan/schemas/creator.md
@@ -1,3 +1,4 @@
 # Creator
 
 ::: simyan.schemas.creator.Creator
+::: simyan.schemas.creator.CreatorEntry

--- a/docs/simyan/schemas/generic_entries.md
+++ b/docs/simyan/schemas/generic_entries.md
@@ -1,5 +1,6 @@
 # Generic Entries
 
+::: simyan.schemas.generic_entries.AlternativeImageEntry
 ::: simyan.schemas.generic_entries.CountEntry
 ::: simyan.schemas.generic_entries.CreatorEntry
 ::: simyan.schemas.generic_entries.GenericEntry

--- a/docs/simyan/schemas/issue.md
+++ b/docs/simyan/schemas/issue.md
@@ -1,3 +1,4 @@
 # Issue
 
 ::: simyan.schemas.issue.Issue
+::: simyan.schemas.issue.IssueEntry

--- a/docs/simyan/schemas/publisher.md
+++ b/docs/simyan/schemas/publisher.md
@@ -1,3 +1,4 @@
 # Publisher
 
 ::: simyan.schemas.publisher.Publisher
+::: simyan.schemas.publisher.PublisherEntry

--- a/docs/simyan/schemas/story_arc.md
+++ b/docs/simyan/schemas/story_arc.md
@@ -1,3 +1,4 @@
 # Story Arc
 
 ::: simyan.schemas.story_arc.StoryArc
+::: simyan.schemas.story_arc.StoryArcEntry

--- a/docs/simyan/schemas/team.md
+++ b/docs/simyan/schemas/team.md
@@ -1,3 +1,4 @@
 # Team
 
 ::: simyan.schemas.team.Team
+::: simyan.schemas.team.TeamEntry

--- a/docs/simyan/schemas/volume.md
+++ b/docs/simyan/schemas/volume.md
@@ -1,3 +1,4 @@
 # Volume
 
 ::: simyan.schemas.volume.Volume
+::: simyan.schemas.volume.VolumeEntry

--- a/poetry.lock
+++ b/poetry.lock
@@ -193,8 +193,8 @@ identify = [
     {file = "identify-2.5.5.tar.gz", hash = "sha256:322a5699daecf7c6fd60e68852f36f2ecbb6a36ff6e6e973e0d2bb6fca203ee6"},
 ]
 idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
@@ -537,7 +537,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=3.5"
-version = "3.3"
+version = "3.4"
 
 [[package]]
 category = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/Metron-Project/Simyan"
-version = "0.10.0"
+version = "0.11.0"
 
 [tool.poetry.dependencies]
 mkdocs = {version = "^1.3.1", optional = true}

--- a/simyan/__init__.py
+++ b/simyan/__init__.py
@@ -1,5 +1,5 @@
 """simyan package entry file."""
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __all__ = ["__version__", "get_cache_root"]
 
 from pathlib import Path

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -21,7 +21,7 @@ from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 
 from simyan import __version__
 from simyan.exceptions import AuthenticationError, CacheError, ServiceError
-from simyan.schemas.character import Character
+from simyan.schemas.character import Character, CharacterEntry
 from simyan.schemas.creator import Creator
 from simyan.schemas.issue import Issue
 from simyan.schemas.location import Location, LocationEntry
@@ -38,7 +38,7 @@ T = TypeVar("T")
 class ComicvineResource(Enum):
     """Enum class for Comicvine Resources."""
 
-    CHARACTER = (4005, "character", List[Character])
+    CHARACTER = (4005, "character", List[CharacterEntry])
     """Details for the Character resource on Comicvine."""
     CREATOR = (4040, "person", List[Creator])
     """Details for the Creator resource on Comicvine."""
@@ -409,7 +409,7 @@ class Comicvine:
 
     def character_list(
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
-    ) -> List[Character]:
+    ) -> List[CharacterEntry]:
         """
         Request data for a list of Characters.
 
@@ -425,7 +425,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/characters/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[Character], results)
+            return parse_obj_as(List[CharacterEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 
@@ -519,7 +519,7 @@ class Comicvine:
         List[Issue],
         List[StoryArc],
         List[Creator],
-        List[Character],
+        List[CharacterEntry],
         List[Team],
         List[LocationEntry],
     ]:

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -26,7 +26,7 @@ from simyan.schemas.creator import Creator, CreatorEntry
 from simyan.schemas.issue import Issue, IssueEntry
 from simyan.schemas.location import Location, LocationEntry
 from simyan.schemas.publisher import Publisher, PublisherEntry
-from simyan.schemas.story_arc import StoryArc
+from simyan.schemas.story_arc import StoryArc, StoryArcEntry
 from simyan.schemas.team import Team
 from simyan.schemas.volume import Volume
 from simyan.sqlite_cache import SQLiteCache
@@ -48,7 +48,7 @@ class ComicvineResource(Enum):
     """Details for the Location resource on Comicvine."""
     PUBLISHER = (4010, "publisher", List[PublisherEntry])
     """Details for the Publisher resource on Comicvine."""
-    STORY_ARC = (4045, "story_arc", List[StoryArc])
+    STORY_ARC = (4045, "story_arc", List[StoryArcEntry])
     """Details for the Story Arc resource on Comicvine."""
     TEAM = (4060, "team", List[Team])
     """Details for the Team resource on Comicvine."""
@@ -206,7 +206,7 @@ class Comicvine:
         self, params: Optional[Dict[str, Any]] = None, max_results: int = 500
     ) -> List[PublisherEntry]:
         """
-        Request data for a list of Publishers.
+        Request data for a list of PublisherEntries.
 
         Args:
             params: Parameters to add to the request.
@@ -247,13 +247,13 @@ class Comicvine:
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
     ) -> List[Volume]:
         """
-        Request data for a list of Volumes.
+        Request data for a list of VolumeEntries.
 
         Args:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of Volume objects.
+            A list of VolumeEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -288,7 +288,7 @@ class Comicvine:
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
     ) -> List[IssueEntry]:
         """
-        Request data for a list of Issues.
+        Request data for a list of IssueEntries.
 
         Args:
             params: Parameters to add to the request.
@@ -308,7 +308,7 @@ class Comicvine:
 
     def story_arc(self, story_arc_id: int) -> StoryArc:
         """
-        Request data for a Story Arc based on its id.
+        Request data for a StoryArc based on its id.
 
         Args:
             story_arc_id: The StoryArc id.
@@ -327,15 +327,15 @@ class Comicvine:
 
     def story_arc_list(
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
-    ) -> List[StoryArc]:
+    ) -> List[StoryArcEntry]:
         """
-        Request data for a list of Story Arcs.
+        Request data for a list of StoryArcEntries.
 
         Args:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of StoryArc objects.
+            A list of StoryArcEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -343,7 +343,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/story_arcs/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[StoryArc], results)
+            return parse_obj_as(List[StoryArcEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 
@@ -370,7 +370,7 @@ class Comicvine:
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
     ) -> List[CreatorEntry]:
         """
-        Request data for a list of Creators.
+        Request data for a list of CreatorEntries.
 
         Args:
             params: Parameters to add to the request.
@@ -411,7 +411,7 @@ class Comicvine:
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
     ) -> List[CharacterEntry]:
         """
-        Request data for a list of Characters.
+        Request data for a list of CharacterEntries.
 
         Args:
             params: Parameters to add to the request.
@@ -452,13 +452,13 @@ class Comicvine:
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
     ) -> List[Team]:
         """
-        Request data for a list of Teams.
+        Request data for a list of TeamEntries.
 
         Args:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of Team objects.
+            A list of TeamEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -493,7 +493,7 @@ class Comicvine:
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
     ) -> List[LocationEntry]:
         """
-        Request data for a list of Locations.
+        Request data for a list of LocationEntries.
 
         Args:
             params: Parameters to add to the request.
@@ -517,7 +517,7 @@ class Comicvine:
         List[PublisherEntry],
         List[Volume],
         List[IssueEntry],
-        List[StoryArc],
+        List[StoryArcEntry],
         List[CreatorEntry],
         List[CharacterEntry],
         List[Team],

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -25,7 +25,7 @@ from simyan.schemas.character import Character, CharacterEntry
 from simyan.schemas.creator import Creator, CreatorEntry
 from simyan.schemas.issue import Issue, IssueEntry
 from simyan.schemas.location import Location, LocationEntry
-from simyan.schemas.publisher import Publisher
+from simyan.schemas.publisher import Publisher, PublisherEntry
 from simyan.schemas.story_arc import StoryArc
 from simyan.schemas.team import Team
 from simyan.schemas.volume import Volume
@@ -46,7 +46,7 @@ class ComicvineResource(Enum):
     """Details for the Issue resource on Comicvine."""
     LOCATION = (4020, "location", List[LocationEntry])
     """Details for the Location resource on Comicvine."""
-    PUBLISHER = (4010, "publisher", List[Publisher])
+    PUBLISHER = (4010, "publisher", List[PublisherEntry])
     """Details for the Publisher resource on Comicvine."""
     STORY_ARC = (4045, "story_arc", List[StoryArc])
     """Details for the Story Arc resource on Comicvine."""
@@ -204,7 +204,7 @@ class Comicvine:
 
     def publisher_list(
         self, params: Optional[Dict[str, Any]] = None, max_results: int = 500
-    ) -> List[Publisher]:
+    ) -> List[PublisherEntry]:
         """
         Request data for a list of Publishers.
 
@@ -212,7 +212,7 @@ class Comicvine:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of Publisher objects.
+            A list of PublisherEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -220,7 +220,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/publishers/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[Publisher], results)
+            return parse_obj_as(List[PublisherEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 
@@ -514,7 +514,7 @@ class Comicvine:
     def search(
         self, resource: ComicvineResource, query: str, max_results: int = 500
     ) -> Union[
-        List[Publisher],
+        List[PublisherEntry],
         List[Volume],
         List[IssueEntry],
         List[StoryArc],

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -22,7 +22,7 @@ from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from simyan import __version__
 from simyan.exceptions import AuthenticationError, CacheError, ServiceError
 from simyan.schemas.character import Character, CharacterEntry
-from simyan.schemas.creator import Creator
+from simyan.schemas.creator import Creator, CreatorEntry
 from simyan.schemas.issue import Issue
 from simyan.schemas.location import Location, LocationEntry
 from simyan.schemas.publisher import Publisher
@@ -40,7 +40,7 @@ class ComicvineResource(Enum):
 
     CHARACTER = (4005, "character", List[CharacterEntry])
     """Details for the Character resource on Comicvine."""
-    CREATOR = (4040, "person", List[Creator])
+    CREATOR = (4040, "person", List[CreatorEntry])
     """Details for the Creator resource on Comicvine."""
     ISSUE = (4000, "issue", List[Issue])
     """Details for the Issue resource on Comicvine."""
@@ -368,7 +368,7 @@ class Comicvine:
 
     def creator_list(
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
-    ) -> List[Creator]:
+    ) -> List[CreatorEntry]:
         """
         Request data for a list of Creators.
 
@@ -384,7 +384,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/people/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[Creator], results)
+            return parse_obj_as(List[CreatorEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 
@@ -518,7 +518,7 @@ class Comicvine:
         List[Volume],
         List[Issue],
         List[StoryArc],
-        List[Creator],
+        List[CreatorEntry],
         List[CharacterEntry],
         List[Team],
         List[LocationEntry],

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -28,7 +28,7 @@ from simyan.schemas.location import Location, LocationEntry
 from simyan.schemas.publisher import Publisher, PublisherEntry
 from simyan.schemas.story_arc import StoryArc, StoryArcEntry
 from simyan.schemas.team import Team, TeamEntry
-from simyan.schemas.volume import Volume
+from simyan.schemas.volume import Volume, VolumeEntry
 from simyan.sqlite_cache import SQLiteCache
 
 MINUTE = 60
@@ -52,7 +52,7 @@ class ComicvineResource(Enum):
     """Details for the Story Arc resource on Comicvine."""
     TEAM = (4060, "team", List[TeamEntry])
     """Details for the Team resource on Comicvine."""
-    VOLUME = (4050, "volume", List[Volume])
+    VOLUME = (4050, "volume", List[VolumeEntry])
     """Details for the Volume resource on Comicvine."""
 
     @property
@@ -245,7 +245,7 @@ class Comicvine:
 
     def volume_list(
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
-    ) -> List[Volume]:
+    ) -> List[VolumeEntry]:
         """
         Request data for a list of VolumeEntries.
 
@@ -261,7 +261,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/volumes/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[Volume], results)
+            return parse_obj_as(List[VolumeEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -27,7 +27,7 @@ from simyan.schemas.issue import Issue, IssueEntry
 from simyan.schemas.location import Location, LocationEntry
 from simyan.schemas.publisher import Publisher, PublisherEntry
 from simyan.schemas.story_arc import StoryArc, StoryArcEntry
-from simyan.schemas.team import Team
+from simyan.schemas.team import Team, TeamEntry
 from simyan.schemas.volume import Volume
 from simyan.sqlite_cache import SQLiteCache
 
@@ -50,7 +50,7 @@ class ComicvineResource(Enum):
     """Details for the Publisher resource on Comicvine."""
     STORY_ARC = (4045, "story_arc", List[StoryArcEntry])
     """Details for the Story Arc resource on Comicvine."""
-    TEAM = (4060, "team", List[Team])
+    TEAM = (4060, "team", List[TeamEntry])
     """Details for the Team resource on Comicvine."""
     VOLUME = (4050, "volume", List[Volume])
     """Details for the Volume resource on Comicvine."""
@@ -450,7 +450,7 @@ class Comicvine:
 
     def team_list(
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
-    ) -> List[Team]:
+    ) -> List[TeamEntry]:
         """
         Request data for a list of TeamEntries.
 
@@ -466,7 +466,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/teams/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[Team], results)
+            return parse_obj_as(List[TeamEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 
@@ -520,7 +520,7 @@ class Comicvine:
         List[StoryArcEntry],
         List[CreatorEntry],
         List[CharacterEntry],
-        List[Team],
+        List[TeamEntry],
         List[LocationEntry],
     ]:
         """

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -515,7 +515,7 @@ class Comicvine:
         self, resource: ComicvineResource, query: str, max_results: int = 500
     ) -> Union[
         List[PublisherEntry],
-        List[Volume],
+        List[VolumeEntry],
         List[IssueEntry],
         List[StoryArcEntry],
         List[CreatorEntry],

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -23,7 +23,7 @@ from simyan import __version__
 from simyan.exceptions import AuthenticationError, CacheError, ServiceError
 from simyan.schemas.character import Character, CharacterEntry
 from simyan.schemas.creator import Creator, CreatorEntry
-from simyan.schemas.issue import Issue
+from simyan.schemas.issue import Issue, IssueEntry
 from simyan.schemas.location import Location, LocationEntry
 from simyan.schemas.publisher import Publisher
 from simyan.schemas.story_arc import StoryArc
@@ -42,7 +42,7 @@ class ComicvineResource(Enum):
     """Details for the Character resource on Comicvine."""
     CREATOR = (4040, "person", List[CreatorEntry])
     """Details for the Creator resource on Comicvine."""
-    ISSUE = (4000, "issue", List[Issue])
+    ISSUE = (4000, "issue", List[IssueEntry])
     """Details for the Issue resource on Comicvine."""
     LOCATION = (4020, "location", List[LocationEntry])
     """Details for the Location resource on Comicvine."""
@@ -286,7 +286,7 @@ class Comicvine:
 
     def issue_list(
         self, params: Optional[Dict[str, Union[str, int]]] = None, max_results: int = 500
-    ) -> List[Issue]:
+    ) -> List[IssueEntry]:
         """
         Request data for a list of Issues.
 
@@ -294,7 +294,7 @@ class Comicvine:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of Issue objects.
+            A list of IssueEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -302,7 +302,7 @@ class Comicvine:
             results = self._retrieve_offset_results(
                 endpoint="/issues/", params=params, max_results=max_results
             )
-            return parse_obj_as(List[Issue], results)
+            return parse_obj_as(List[IssueEntry], results)
         except ValidationError as err:
             raise ServiceError(err)
 
@@ -376,7 +376,7 @@ class Comicvine:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of Creator objects.
+            A list of CreatorEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -417,7 +417,7 @@ class Comicvine:
             params: Parameters to add to the request.
             max_results: Limits the amount of results looked up and returned.
         Returns:
-            A list of Character objects.
+            A list of CharacterEntry objects.
         Raises:
             ServiceError: If there is an issue with validating the response.
         """
@@ -516,7 +516,7 @@ class Comicvine:
     ) -> Union[
         List[Publisher],
         List[Volume],
-        List[Issue],
+        List[IssueEntry],
         List[StoryArc],
         List[CreatorEntry],
         List[CharacterEntry],

--- a/simyan/schemas/character.py
+++ b/simyan/schemas/character.py
@@ -66,7 +66,6 @@ class Character(BaseModel):
     friendly_teams: List[GenericEntry] = Field(default_factory=list, alias="team_friends")
     friends: List[GenericEntry] = Field(default_factory=list, alias="character_friends")
     gender: int
-    id_: int = Field(alias="id")
     character_id: int = Field(alias="id")
     image: ImageEntry
     issue_count: Optional[int] = Field(default=None, alias="count_of_issue_appearances")

--- a/simyan/schemas/character.py
+++ b/simyan/schemas/character.py
@@ -137,7 +137,7 @@ class CharacterEntry(BaseModel):
     @property
     def alias_list(self) -> List[str]:
         r"""
-        List of aliases the Character has used.
+        List of aliases the CharacterEntry has used.
 
         Returns:
             List of aliases, split by `~\r\n`

--- a/simyan/schemas/character.py
+++ b/simyan/schemas/character.py
@@ -35,7 +35,6 @@ class Character(BaseModel):
         friendly_teams: List of friendly teams the Character has.
         friends: List of friends the Character has.
         gender: Character gender.
-        id_: Identifier used by Comicvine. **Deprecated:** Use character_id instead
         character_id: Identifier used by Comicvine.
         image: Different sized images, posters and thumbnails for the Character.
         issue_count: Number of issues the Character appears in.

--- a/simyan/schemas/character.py
+++ b/simyan/schemas/character.py
@@ -4,8 +4,9 @@ The Character module.
 This module provides the following classes:
 
 - Character
+- CharacterEntry
 """
-__all__ = ["Character"]
+__all__ = ["Character", "CharacterEntry"]
 import re
 from datetime import date, datetime
 from typing import List, Optional
@@ -79,6 +80,59 @@ class Character(BaseModel):
     summary: Optional[str] = Field(default=None, alias="deck")
     teams: List[GenericEntry] = Field(default_factory=list)
     volumes: List[GenericEntry] = Field(default_factory=list, alias="volume_credits")
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the Character has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class CharacterEntry(BaseModel):
+    r"""
+    The CharacterEntry object contains information for a character.
+
+    Attributes:
+        aliases: List of names used by the CharacterEntry, separated by `~\r\n`.
+        api_url: Url to the resource in the Comicvine API.
+        date_added: Date and time when the CharacterEntry was added.
+        date_last_updated: Date and time when the CharacterEntry was last updated.
+        date_of_birth: Date when the CharacterEntry was born.
+        description: Long description of the CharacterEntry.
+        first_issue: First issue the CharacterEntry appeared in.
+        gender: CharacterEntry gender.
+        character_id: Identifier used by Comicvine.
+        image: Different sized images, posters and thumbnails for the CharacterEntry.
+        issue_count: Number of issues the CharacterEntry appears in.
+        name: Real name or public identity of CharacterEntry.
+        origin: The type of CharacterEntry.
+        publisher: The publisher of the CharacterEntry.
+        real_name: Name of the CharacterEntry.
+        site_url: Url to the resource in Comicvine.
+        summary: Short description of the CharacterEntry.
+    """
+
+    aliases: Optional[str] = None
+    api_url: str = Field(alias="api_detail_url")
+    date_added: datetime
+    date_last_updated: datetime
+    date_of_birth: Optional[date] = Field(default=None, alias="birth")
+    description: Optional[str] = None
+    first_issue: IssueEntry = Field(alias="first_appeared_in_issue")
+    gender: int
+    character_id: int = Field(alias="id")
+    image: ImageEntry
+    issue_count: Optional[int] = Field(default=None, alias="count_of_issue_appearances")
+    name: str
+    origin: Optional[GenericEntry] = None
+    publisher: GenericEntry
+    real_name: Optional[str] = None
+    site_url: str = Field(alias="site_detail_url")
+    summary: Optional[str] = Field(default=None, alias="deck")
 
     @property
     def alias_list(self) -> List[str]:

--- a/simyan/schemas/creator.py
+++ b/simyan/schemas/creator.py
@@ -58,7 +58,6 @@ class Creator(BaseModel):
     email: Optional[str] = None
     gender: int
     hometown: Optional[str] = None
-    id_: int = Field(alias="id")
     creator_id: int = Field(alias="id")
     image: ImageEntry
     issue_count: Optional[int] = Field(default=None, alias="count_of_isssue_appearances")

--- a/simyan/schemas/creator.py
+++ b/simyan/schemas/creator.py
@@ -33,7 +33,6 @@ class Creator(BaseModel):
         email: Email address of the Creator.
         gender: Creator gender.
         hometown: Hometown of the Creator.
-        id_: Identifier used by Comicvine. **Deprecated:** Use creator_id instead.
         creator_id: Identifier used by Comicvine.
         image: Different sized images, posters and thumbnails for the Creator.
         issue_count: Number of issues the Creator appears in.

--- a/simyan/schemas/creator.py
+++ b/simyan/schemas/creator.py
@@ -4,8 +4,9 @@ The Creator module.
 This module provides the following classes:
 
 - Creator
+- CreatorEntry
 """
-__all__ = ["Creator"]
+__all__ = ["Creator", "CreatorEntry"]
 import re
 from datetime import date, datetime
 from typing import List, Optional
@@ -79,6 +80,68 @@ class Creator(BaseModel):
     def alias_list(self) -> List[str]:
         r"""
         List of aliases the Creator has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class CreatorEntry(BaseModel):
+    r"""
+    The CreatorEntry object contains information for a creator.
+
+    Attributes:
+        aliases: List of names used by the CreatorEntry, separated by `~\r\n`
+        api_url: Url to the resource in the Comicvine API.
+        country: Country of origin.
+        date_added: Date and time when the CreatorEntry was added.
+        date_last_updated: Date and time when the CreatorEntry was last updated.
+        date_of_birth: Date when the CreatorEntry was born.
+        date_of_death: Date when the CreatorEntry died.
+        description: Long description of the CreatorEntry.
+        email: Email address of the CreatorEntry.
+        gender: CreatorEntry gender.
+        hometown: Hometown of the CreatorEntry.
+        creator_id: Identifier used by Comicvine.
+        image: Different sized images, posters and thumbnails for the CreatorEntry.
+        issue_count: Number of issues the CreatorEntry appears in.
+        name: Name/Title of the CreatorEntry.
+        site_url: Url to the resource in Comicvine.
+        summary: Short description of the CreatorEntry.
+        website: Url to the CreatorEntry's website.
+    """
+
+    aliases: Optional[str] = None
+    api_url: str = Field(alias="api_detail_url")
+    country: Optional[str] = None
+    date_added: datetime
+    date_last_updated: datetime
+    date_of_birth: Optional[date] = Field(default=None, alias="birth")
+    date_of_death: Optional[date] = Field(default=None, alias="death")
+    description: Optional[str] = None
+    email: Optional[str] = None
+    gender: int
+    hometown: Optional[str] = None
+    creator_id: int = Field(alias="id")
+    image: ImageEntry
+    issue_count: Optional[int] = Field(default=None, alias="count_of_isssue_appearances")
+    name: str
+    site_url: str = Field(alias="site_detail_url")
+    summary: Optional[str] = Field(default=None, alias="deck")
+    website: Optional[str] = None
+
+    def __init__(self, **data):
+        if "death" in data and data["death"] is not None:
+            data["death"] = data["death"]["date"].split()[0]
+        if data["birth"]:
+            data["birth"] = data["birth"].split()[0]
+        super().__init__(**data)
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the CreatorEntry has used.
 
         Returns:
             List of aliases, split by `~\r\n`

--- a/simyan/schemas/generic_entries.py
+++ b/simyan/schemas/generic_entries.py
@@ -8,8 +8,16 @@ This module provides the following classes:
 - IssueEntry
 - CreatorEntry
 - ImageEntry
+- AlternativeImageEntry
 """
-__all__ = ["GenericEntry", "CountEntry", "IssueEntry", "CreatorEntry", "ImageEntry"]
+__all__ = [
+    "GenericEntry",
+    "CountEntry",
+    "IssueEntry",
+    "CreatorEntry",
+    "ImageEntry",
+    "AlternativeImageEntry",
+]
 import re
 from typing import List, Optional
 
@@ -35,8 +43,6 @@ class GenericEntry(BaseModel):
     class Config:
         """Any extra fields will raise an error."""
 
-        anystr_strip_whitespace = True
-        allow_population_by_field_name = True
         extra = Extra.forbid
 
 
@@ -110,3 +116,30 @@ class ImageEntry(BaseModel):
     tiny: str = Field(alias="tiny_url")
     original: str = Field(alias="original_url")
     tags: Optional[str] = Field(default=None, alias="image_tags")
+
+    class Config:
+        """Any extra fields will raise an error."""
+
+        extra = Extra.forbid
+
+
+class AlternativeImageEntry(BaseModel):
+    """
+    The AlternativeImageEntry object contains image information.
+
+    Attributes:
+        url: Url to image.
+        id_: Id of image.
+        caption: Caption/description of the image.
+        tags:
+    """
+
+    url: str = Field(alias="original_url")
+    id_: int = Field(alias="id")
+    caption: Optional[str] = None
+    tags: Optional[str] = Field(default=None, alias="image_tags")
+
+    class Config:
+        """Any extra fields will raise an error."""
+
+        extra = Extra.forbid

--- a/simyan/schemas/generic_entries.py
+++ b/simyan/schemas/generic_entries.py
@@ -51,6 +51,10 @@ class CountEntry(GenericEntry):
     The CountEntry object contains generic information with an added count field.
 
     Attributes:
+        api_url: Url to the resource in the Comicvine API.
+        id_: Identifier used by Comicvine.
+        name:
+        site_url: Url to the resource in Comicvine.
         count:
     """
 
@@ -62,6 +66,10 @@ class IssueEntry(GenericEntry):
     The IssueEntry object contains generic information with an added number field.
 
     Attributes:
+        api_url: Url to the resource in the Comicvine API.
+        id_: Identifier used by Comicvine.
+        name:
+        site_url: Url to the resource in Comicvine.
         number:
     """
 
@@ -73,6 +81,10 @@ class CreatorEntry(GenericEntry):
     The CreatorEntry object contains generic information with an added roles field.
 
     Attributes:
+        api_url: Url to the resource in the Comicvine API.
+        id_: Identifier used by Comicvine.
+        name:
+        site_url: Url to the resource in Comicvine.
         roles: List of roles used by the Creator, separated by `~\r\n`
     """
 

--- a/simyan/schemas/issue.py
+++ b/simyan/schemas/issue.py
@@ -4,8 +4,9 @@ The Issue module.
 This module provides the following classes:
 
 - Issue
+- IssueEntry
 """
-__all__ = ["Issue"]
+__all__ = ["Issue", "IssueEntry"]
 import re
 from datetime import date, datetime
 from typing import List, Optional
@@ -13,7 +14,12 @@ from typing import List, Optional
 from pydantic import Field
 
 from simyan.schemas import BaseModel
-from simyan.schemas.generic_entries import CreatorEntry, GenericEntry, ImageEntry
+from simyan.schemas.generic_entries import (
+    AlternativeImageEntry,
+    CreatorEntry,
+    GenericEntry,
+    ImageEntry,
+)
 
 
 class Issue(BaseModel):
@@ -22,6 +28,7 @@ class Issue(BaseModel):
 
     Attributes:
         aliases: List of names used by the Issue, separated by `~\r\n`.
+        alternative_images: List of different images associated with the Issue.
         api_url: Url to the resource in the Comicvine API.
         characters: List of characters in the Issue.
         concepts: List of concepts in the Issue.
@@ -53,6 +60,9 @@ class Issue(BaseModel):
     """
 
     aliases: Optional[str] = None
+    alternative_images: List[AlternativeImageEntry] = Field(
+        default_factory=list, alias="associated_images"
+    )
     api_url: str = Field(alias="api_detail_url")
     characters: List[GenericEntry] = Field(default_factory=list, alias="character_credits")
     concepts: List[GenericEntry] = Field(default_factory=list, alias="concept_credits")
@@ -98,6 +108,57 @@ class Issue(BaseModel):
         if "first_appearance_teams" in data and not data["first_appearance_teams"]:
             data["first_appearance_teams"] = []
         super().__init__(**data)
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the Issue has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class IssueEntry(BaseModel):
+    r"""
+    The IssueEntry object contains information for an issue.
+
+    Attributes:
+        aliases: List of names used by the IssueEntry, separated by `~\r\n`.
+        alternative_images: List of different images associated with the IssueEntry.
+        api_url: Url to the resource in the Comicvine API.
+        cover_date: Date on the cover of the IssueEntry.
+        date_added: Date and time when the IssueEntry was added.
+        date_last_updated: Date and time when the IssueEntry was last updated.
+        description: Long description of the IssueEntry.
+        issue_id: Identifier used by Comicvine.
+        image: Different sized images, posters and thumbnails for the IssueEntry.
+        name: Name/Title of the IssueEntry.
+        number: The IssueEntry number.
+        site_url: Url to the resource in Comicvine.
+        store_date: Date the IssueEntry went on sale on stores.
+        summary: Short description of the IssueEntry.
+        volume: The volume the IssueEntry is in.
+    """
+
+    aliases: Optional[str] = None
+    alternative_images: List[AlternativeImageEntry] = Field(
+        default_factory=list, alias="associated_images"
+    )
+    api_url: str = Field(alias="api_detail_url")
+    cover_date: Optional[date] = None
+    date_added: datetime
+    date_last_updated: datetime
+    description: Optional[str] = None
+    issue_id: int = Field(alias="id")
+    image: ImageEntry
+    name: Optional[str] = None
+    number: str = Field(alias="issue_number")
+    site_url: str = Field(alias="site_detail_url")
+    store_date: Optional[date] = None
+    summary: Optional[str] = Field(default=None, alias="deck")
+    volume: GenericEntry
 
     @property
     def alias_list(self) -> List[str]:

--- a/simyan/schemas/issue.py
+++ b/simyan/schemas/issue.py
@@ -37,7 +37,6 @@ class Issue(BaseModel):
         first_appearance_objects: List of objects which first appear in the Issue.
         first_appearance_story_arcs: List of story arcs which first appear in the Issue.
         first_appearance_teams: List of teams who first appear in the Issue.
-        id_: Identifier used by Comicvine. **Deprecated:** Use issue_id instead.
         issue_id: Identifier used by Comicvine.
         image: Different sized images, posters and thumbnails for the Issue.
         locations: List of locations in the Issue.

--- a/simyan/schemas/issue.py
+++ b/simyan/schemas/issue.py
@@ -71,7 +71,6 @@ class Issue(BaseModel):
         default_factory=list, alias="first_appearance_storyarcs"
     )
     first_appearance_teams: List[GenericEntry] = Field(default_factory=list)
-    id_: int = Field(alias="id")
     issue_id: int = Field(alias="id")
     image: ImageEntry
     locations: List[GenericEntry] = Field(default_factory=list, alias="location_credits")

--- a/simyan/schemas/publisher.py
+++ b/simyan/schemas/publisher.py
@@ -47,7 +47,6 @@ class Publisher(BaseModel):
     date_added: datetime
     date_last_updated: datetime
     description: Optional[str] = None
-    id_: int = Field(alias="id")
     publisher_id: int = Field(alias="id")
     image: ImageEntry
     location_address: Optional[str] = None

--- a/simyan/schemas/publisher.py
+++ b/simyan/schemas/publisher.py
@@ -27,7 +27,6 @@ class Publisher(BaseModel):
         date_added: Date and time when the Publisher was added.
         date_last_updated: Date and time when the Publisher was last updated.
         description: Long description of the Publisher.
-        id_: Identifier used by Comicvine. **Deprecated:** Use publisher_id instead.
         publisher_id: Identifier used by Comicvine.
         image: Different sized images, posters and thumbnails for the Publisher.
         location_address: Address where the Publisher is located.

--- a/simyan/schemas/publisher.py
+++ b/simyan/schemas/publisher.py
@@ -4,8 +4,9 @@ The Publisher module.
 This module provides the following classes:
 
 - Publisher
+- PublisherEntry
 """
-__all__ = ["Publisher"]
+__all__ = ["Publisher", "PublisherEntry"]
 import re
 from datetime import datetime
 from typing import List, Optional
@@ -57,6 +58,51 @@ class Publisher(BaseModel):
     summary: Optional[str] = Field(default=None, alias="deck")
     teams: List[GenericEntry] = Field(default_factory=list)
     volumes: List[GenericEntry] = Field(default_factory=list)
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the Publisher has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class PublisherEntry(BaseModel):
+    r"""
+    The PublisherEntry object contains information for a publisher.
+
+    Attributes:
+        aliases: List of names used by the PublisherEntry, separated by `~\r\n`.
+        api_url: Url to the resource in the Comicvine API.
+        date_added: Date and time when the PublisherEntry was added.
+        date_last_updated: Date and time when the PublisherEntry was last updated.
+        description: Long description of the PublisherEntry.
+        publisher_id: Identifier used by Comicvine.
+        image: Different sized images, posters and thumbnails for the PublisherEntry.
+        location_address: Address where the PublisherEntry is located.
+        location_city: City where the PublisherEntry is located.
+        location_state: State where the PublisherEntry is located.
+        name: Name/Title of the PublisherEntry.
+        site_url: Url to the resource in Comicvine.
+        summary: Short description of the PublisherEntry.
+    """
+
+    aliases: Optional[str] = None
+    api_url: str = Field(alias="api_detail_url")
+    date_added: datetime
+    date_last_updated: datetime
+    description: Optional[str] = None
+    publisher_id: int = Field(alias="id")
+    image: ImageEntry
+    location_address: Optional[str] = None
+    location_city: Optional[str] = None
+    location_state: Optional[str] = None
+    name: str
+    site_url: str = Field(alias="site_detail_url")
+    summary: Optional[str] = Field(default=None, alias="deck")
 
     @property
     def alias_list(self) -> List[str]:

--- a/simyan/schemas/story_arc.py
+++ b/simyan/schemas/story_arc.py
@@ -4,8 +4,9 @@ The StoryArc module.
 This module provides the following classes:
 
 - StoryArc
+- StoryArcEntry
 """
-__all__ = ["StoryArc"]
+__all__ = ["StoryArc", "StoryArcEntry"]
 import re
 from datetime import datetime
 from typing import List, Optional
@@ -21,20 +22,20 @@ class StoryArc(BaseModel):
     The StoryArc object contains information for a story arc.
 
     Attributes:
-        aliases: List of names used by the Story Arc, separated by `~\r\n`.
+        aliases: List of names used by the StoryArc, separated by `~\r\n`.
         api_url: Url to the resource in the Comicvine API.
-        date_added: Date and time when the Story Arc was added.
-        date_last_updated: Date and time when the Story Arc was last updated.
-        description: Long description of the Story Arc.
-        first_issue: First issue of the Story Arc.
+        date_added: Date and time when the StoryArc was added.
+        date_last_updated: Date and time when the StoryArc was last updated.
+        description: Long description of the StoryArc.
+        first_issue: First issue of the StoryArc.
         story_arc_id: Identifier used by Comicvine.
-        image: Different sized images, posters and thumbnails for the Story Arc.
-        issue_count: Number of issues in the Story Arc.
-        issues: List of issues in the Story Arc.
-        name: Name/Title of the Story Arc.
-        publisher: The publisher of the Story Arc.
+        image: Different sized images, posters and thumbnails for the StoryArc.
+        issue_count: Number of issues in the StoryArc.
+        issues: List of issues in the StoryArc.
+        name: Name/Title of the StoryArc.
+        publisher: The publisher of the StoryArc.
         site_url: Url to the resource in Comicvine.
-        summary: Short description of the Story Arc.
+        summary: Short description of the StoryArc.
     """
 
     aliases: Optional[str] = None
@@ -55,7 +56,52 @@ class StoryArc(BaseModel):
     @property
     def alias_list(self) -> List[str]:
         r"""
-        List of aliases the Story Arc has used.
+        List of aliases the StoryArc has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class StoryArcEntry(BaseModel):
+    r"""
+    The StoryArcEntry object contains information for a story arc.
+
+    Attributes:
+        aliases: List of names used by the StoryArcEntry, separated by `~\r\n`.
+        api_url: Url to the resource in the Comicvine API.
+        date_added: Date and time when the StoryArcEntry was added.
+        date_last_updated: Date and time when the StoryArcEntry was last updated.
+        description: Long description of the StoryArcEntry.
+        first_issue: First issue of the StoryArcEntry.
+        story_arc_id: Identifier used by Comicvine.
+        image: Different sized images, posters and thumbnails for the StoryArcEntry.
+        issue_count: Number of issues in the StoryArcEntry.
+        name: Name/Title of the StoryArcEntry.
+        publisher: The publisher of the StoryArcEntry.
+        site_url: Url to the resource in Comicvine.
+        summary: Short description of the StoryArcEntry.
+    """
+
+    aliases: Optional[str] = None
+    api_url: str = Field(alias="api_detail_url")
+    date_added: datetime
+    date_last_updated: datetime
+    description: Optional[str] = None
+    first_issue: Optional[IssueEntry] = Field(default=None, alias="first_appeared_in_issue")
+    story_arc_id: int = Field(alias="id")
+    image: ImageEntry
+    issue_count: int = Field(alias="count_of_isssue_appearances")
+    name: str
+    publisher: Optional[GenericEntry] = None
+    site_url: str = Field(alias="site_detail_url")
+    summary: Optional[str] = Field(default=None, alias="deck")
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the StoryArcEntry has used.
 
         Returns:
             List of aliases, split by `~\r\n`

--- a/simyan/schemas/story_arc.py
+++ b/simyan/schemas/story_arc.py
@@ -27,7 +27,6 @@ class StoryArc(BaseModel):
         date_last_updated: Date and time when the Story Arc was last updated.
         description: Long description of the Story Arc.
         first_issue: First issue of the Story Arc.
-        id_: Identifier used by Comicvine. **Deprecated:** Use story_arc_id instead.
         story_arc_id: Identifier used by Comicvine.
         image: Different sized images, posters and thumbnails for the Story Arc.
         issue_count: Number of issues in the Story Arc.

--- a/simyan/schemas/story_arc.py
+++ b/simyan/schemas/story_arc.py
@@ -44,7 +44,6 @@ class StoryArc(BaseModel):
     date_last_updated: datetime
     description: Optional[str] = None
     first_issue: Optional[IssueEntry] = Field(default=None, alias="first_appeared_in_issue")
-    id_: int = Field(alias="id")
     story_arc_id: int = Field(alias="id")
     image: ImageEntry
     issue_count: int = Field(alias="count_of_isssue_appearances")

--- a/simyan/schemas/team.py
+++ b/simyan/schemas/team.py
@@ -4,8 +4,9 @@ The Team module.
 This module provides the following classes:
 
 - Team
+- TeamEntry
 """
-__all__ = ["Team"]
+__all__ = ["Team", "TeamEntry"]
 import re
 from datetime import datetime
 from typing import List, Optional
@@ -72,6 +73,53 @@ class Team(BaseModel):
     def alias_list(self) -> List[str]:
         r"""
         List of aliases the Team has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class TeamEntry(BaseModel):
+    r"""
+    The TeamEntry object contains information for a team.
+
+    Attributes:
+        aliases: List of names used by the TeamEntry, separated by `~\r\n`.
+        api_url: Url to the resource in the Comicvine API.
+        date_added: Date and time when the TeamEntry was added.
+        date_last_updated: Date and time when the TeamEntry was last updated.
+        description: Long description of the TeamEntry.
+        first_issue: First issue the TeamEntry appeared in.
+        image: Different sized images, posters and thumbnails for the TeamEntry.
+        issue_count: Number of issues the TeamEntry appears in.
+        member_count: Number of members in the TeamEntry.
+        name: Name/Title of the TeamEntry.
+        publisher: The publisher of the TeamEntry.
+        site_url: Url to the resource in Comicvine.
+        summary: Short description of the TeamEntry.
+        team_id: Identifier used by Comicvine.
+    """
+
+    aliases: Optional[str] = None
+    api_url: str = Field(alias="api_detail_url")
+    date_added: datetime
+    date_last_updated: datetime
+    description: Optional[str] = None
+    first_issue: IssueEntry = Field(alias="first_appeared_in_issue")
+    image: ImageEntry
+    issue_count: int = Field(alias="count_of_isssue_appearances")
+    member_count: int = Field(alias="count_of_team_members")
+    name: str
+    publisher: GenericEntry
+    site_url: str = Field(alias="site_detail_url")
+    summary: Optional[str] = Field(alias="deck", default=None)
+    team_id: int = Field(alias="id")
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the TeamEntry has used.
 
         Returns:
             List of aliases, split by `~\r\n`

--- a/simyan/schemas/volume.py
+++ b/simyan/schemas/volume.py
@@ -30,7 +30,6 @@ class Volume(BaseModel):
         date_last_updated: Date and time when the Volume was last updated.
         description: Long description of the Volume.
         first_issue: First issue of the Volume.
-        id_: Identifier used by Comicvine. **Deprecated:** Use volume_id instead.
         volume_id: Identifier used by Comicvine.
         image: Different sized images, posters and thumbnails for the Volume.
         issue_count: Number of issues in the Volume.

--- a/simyan/schemas/volume.py
+++ b/simyan/schemas/volume.py
@@ -4,8 +4,9 @@ The Volume module.
 This module provides the following classes:
 
 - Volume
+- VolumeEntry
 """
-__all__ = ["Volume"]
+__all__ = ["Volume", "VolumeEntry"]
 import re
 from datetime import datetime
 from typing import List, Optional
@@ -77,6 +78,62 @@ class Volume(BaseModel):
     def alias_list(self) -> List[str]:
         r"""
         List of aliases the Volume has used.
+
+        Returns:
+            List of aliases, split by `~\r\n`
+        """
+        return re.split(r"[~\r\n]+", self.aliases) if self.aliases else []
+
+
+class VolumeEntry(BaseModel):
+    r"""
+    The VolumeEntry object contains information for a volume.
+
+    Attributes:
+        aliases: List of names used by the VolumeEntry, separated by `~\r\n`.
+        api_url: Url to the resource in the Comicvine API.
+        date_added: Date and time when the VolumeEntry was added.
+        date_last_updated: Date and time when the VolumeEntry was last updated.
+        description: Long description of the VolumeEntry.
+        first_issue: First issue of the VolumeEntry.
+        volume_id: Identifier used by Comicvine.
+        image: Different sized images, posters and thumbnails for the VolumeEntry.
+        issue_count: Number of issues in the VolumeEntry.
+        last_issue: Last issue of the VolumeEntry.
+        name: Name/Title of the VolumeEntry.
+        publisher: The publisher of the VolumeEntry.
+        site_url: Url to the resource in Comicvine.
+        start_year: The year the VolumeEntry started.
+        summary: Short description of the VolumeEntry.
+    """
+
+    aliases: Optional[str] = None
+    api_url: str = Field(alias="api_detail_url")
+    date_added: datetime
+    date_last_updated: datetime
+    description: Optional[str] = None
+    first_issue: Optional[IssueEntry] = None
+    volume_id: int = Field(alias="id")
+    image: ImageEntry
+    issue_count: int = Field(alias="count_of_issues")
+    last_issue: Optional[IssueEntry] = None
+    name: str
+    publisher: Optional[GenericEntry] = None
+    site_url: str = Field(alias="site_detail_url")
+    start_year: Optional[int] = None
+    summary: Optional[str] = Field(default=None, alias="deck")
+
+    def __init__(self, **data):
+        try:
+            data["start_year"] = int(data["start_year"] or "")
+        except ValueError:
+            data["start_year"] = None
+        super().__init__(**data)
+
+    @property
+    def alias_list(self) -> List[str]:
+        r"""
+        List of aliases the VolumeEntry has used.
 
         Returns:
             List of aliases, split by `~\r\n`

--- a/simyan/schemas/volume.py
+++ b/simyan/schemas/volume.py
@@ -54,7 +54,6 @@ class Volume(BaseModel):
     date_last_updated: datetime
     description: Optional[str] = None
     first_issue: Optional[IssueEntry] = None
-    id_: int = Field(alias="id")
     volume_id: int = Field(alias="id")
     image: ImageEntry
     issue_count: int = Field(alias="count_of_issues")

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -1,7 +1,7 @@
 """
 The Characters test module.
 
-This module contains tests for Character objects and CharacterEntry objects.
+This module contains tests for Character and CharacterEntry objects.
 """
 from datetime import datetime
 

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -1,7 +1,7 @@
 """
 The Characters test module.
 
-This module contains tests for Character objects.
+This module contains tests for Character objects and CharacterEntry objects.
 """
 from datetime import datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.character import Character
+from simyan.schemas.character import CharacterEntry
 
 
 def test_character(session: Comicvine):
@@ -74,27 +74,16 @@ def test_character_list(session: Comicvine):
         "Omega Lantern",
     ]
     assert result.api_url == "https://comicvine.gamespot.com/api/character/4005-40431/"
-    assert result.creators == []
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 42)
     assert result.date_of_birth is None
-    assert result.deaths == []
-    assert result.enemies == []
-    assert result.enemy_teams == []
     assert result.first_issue.id_ == 38445
-    assert result.friendly_teams == []
-    assert result.friends == []
     assert result.gender == 1
     assert result.issue_count == 1565
-    assert result.issues == []
     assert result.name == "Kyle Rayner"
     assert result.origin.id_ == 4
-    assert result.powers == []
     assert result.publisher.id_ == 10
     assert result.real_name == "Kyle Rayner"
     assert result.site_url == "https://comicvine.gamespot.com/kyle-rayner/4005-40431/"
-    assert result.story_arcs == []
-    assert result.teams == []
-    assert result.volumes == []
 
 
 def test_character_list_empty(session: Comicvine):
@@ -112,7 +101,7 @@ def test_character_list_max_results(session: Comicvine):
 def test_search_character(session: Comicvine):
     """Test using the search endpoint for a list of Characters."""
     results = session.search(resource=ComicvineResource.CHARACTER, query="Kyle Rayner")
-    assert all(isinstance(x, Character) for x in results)
+    assert all(isinstance(x, CharacterEntry) for x in results)
 
 
 def test_search_character_max_results(session: Comicvine):
@@ -120,5 +109,5 @@ def test_search_character_max_results(session: Comicvine):
     results = session.search(
         resource=ComicvineResource.CHARACTER, query="Kyle Rayner", max_results=10
     )
-    assert all(isinstance(x, Character) for x in results)
+    assert all(isinstance(x, CharacterEntry) for x in results)
     assert len(results) == 10

--- a/tests/test_creators.py
+++ b/tests/test_creators.py
@@ -1,7 +1,7 @@
 """
 The Creators test module.
 
-This module contains tests for Creator objects and CreatorEntry objects.
+This module contains tests for Creator and CreatorEntry objects.
 """
 from datetime import date, datetime
 

--- a/tests/test_creators.py
+++ b/tests/test_creators.py
@@ -1,7 +1,7 @@
 """
 The Creators test module.
 
-This module contains tests for Creator objects.
+This module contains tests for Creator objects and CreatorEntry objects.
 """
 from datetime import date, datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.creator import Creator
+from simyan.schemas.creator import CreatorEntry
 
 
 def test_creator(session: Comicvine):
@@ -52,7 +52,6 @@ def test_creator_list(session: Comicvine):
 
     assert result.alias_list == ["Geoffrey Johns"]
     assert result.api_url == "https://comicvine.gamespot.com/api/person/4040-40439/"
-    assert result.characters == []
     assert result.country == "United States"
     assert result.date_added == datetime(2008, 6, 6, 11, 28, 14)
     assert result.date_of_birth == date(1973, 1, 25)
@@ -61,11 +60,8 @@ def test_creator_list(session: Comicvine):
     assert result.gender == 1
     assert result.hometown == "Detroit, MI"
     assert result.issue_count is None
-    assert result.issues == []
     assert result.name == "Geoff Johns"
     assert result.site_url == "https://comicvine.gamespot.com/geoff-johns/4040-40439/"
-    assert result.story_arcs == []
-    assert result.volumes == []
     assert result.website == "http://www.geoffjohns.com"
 
 
@@ -84,13 +80,13 @@ def test_creator_list_max_results(session: Comicvine):
 def test_search_creator(session: Comicvine):
     """Test using the search endpoint for a list of Creators."""
     results = session.search(resource=ComicvineResource.CREATOR, query="Geoff")
-    assert all(isinstance(x, Creator) for x in results)
+    assert all(isinstance(x, CreatorEntry) for x in results)
 
 
 def test_search_creator_max_results(session: Comicvine):
     """Test search endpoint with max_results."""
     results = session.search(resource=ComicvineResource.CREATOR, query="Geoff", max_results=10)
-    assert all(isinstance(x, Creator) for x in results)
+    assert all(isinstance(x, CreatorEntry) for x in results)
     assert len(results) == 10
 
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -113,7 +113,7 @@ def test_issue_bad_cover_date(session: Comicvine):
     xmen_2 = session.issue(issue_id=6787)
     assert xmen_2.store_date is None
     assert xmen_2.cover_date == date(1963, 11, 1)
-    assert xmen_2.id_ == 6787
+    assert xmen_2.issue_id == 6787
     assert xmen_2.number == "2"
     assert len(xmen_2.creators) == 4
     assert xmen_2.creators[0].name == "Jack Kirby"
@@ -143,7 +143,7 @@ def test_issue_no_description(session: Comicvine):
 def test_issue_list_no_description(session: Comicvine):
     """Test issue_list endpoint to return result that has a null/no description."""
     results = session.issue_list(params={"filter": "volume:18006"})
-    result = [x for x in results if x.id_ == 134272][0]
+    result = [x for x in results if x.issue_id == 134272][0]
     assert result.description is None
 
 
@@ -156,5 +156,5 @@ def test_issue_no_cover_date(session: Comicvine):
 def test_issue_list_no_cover_date(session: Comicvine):
     """Test issue_list endpoint to return result that has a null/no cover_date."""
     results = session.issue_list(params={"filter": "volume:3088"})
-    result = [x for x in results if x.id_ == 325298][0]
+    result = [x for x in results if x.issue_id == 325298][0]
     assert result.cover_date is None

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,7 +1,7 @@
 """
 The Issues test module.
 
-This module contains tests for Issue objects.
+This module contains tests for Issue and IssueEntry objects.
 """
 from datetime import date, datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.issue import Issue
+from simyan.schemas.issue import IssueEntry
 
 
 def test_issue(session: Comicvine):
@@ -19,6 +19,7 @@ def test_issue(session: Comicvine):
     assert result.issue_id == 111265
 
     assert result.alias_list == []
+    assert len(result.alternative_images) == 1
     assert result.api_url == "https://comicvine.gamespot.com/api/issue/4000-111265/"
     assert len(result.characters) == 7
     assert len(result.concepts) == 1
@@ -58,28 +59,14 @@ def test_issue_list(session: Comicvine):
     assert result is not None
 
     assert result.alias_list == []
+    assert len(result.alternative_images) == 1
     assert result.api_url == "https://comicvine.gamespot.com/api/issue/4000-111265/"
-    assert result.characters == []
-    assert result.concepts == []
     assert result.cover_date == date(2005, 7, 1)
-    assert result.creators == []
     assert result.date_added == datetime(2008, 6, 6, 11, 21, 45)
-    assert result.deaths == []
-    assert result.first_appearance_characters == []
-    assert result.first_appearance_concepts == []
-    assert result.first_appearance_locations == []
-    assert result.first_appearance_objects == []
-    assert result.first_appearance_story_arcs == []
-    assert result.first_appearance_teams == []
-    assert result.locations == []
     assert result.name == "Airborne"
     assert result.number == "1"
-    assert result.objects == []
     assert result.site_url == "https://comicvine.gamespot.com/green-lantern-1-airborne/4000-111265/"
     assert result.store_date == date(2005, 5, 18)
-    assert result.story_arcs == []
-    assert result.teams == []
-    assert result.teams_disbanded == []
     assert result.volume.id_ == 18216
 
 
@@ -98,13 +85,13 @@ def test_issue_list_max_results(session: Comicvine):
 def test_search_issue(session: Comicvine):
     """Test using the search endpoint for a list of Issues."""
     results = session.search(resource=ComicvineResource.ISSUE, query="Lantern")
-    assert all(isinstance(x, Issue) for x in results)
+    assert all(isinstance(x, IssueEntry) for x in results)
 
 
 def test_search_issue_max_results(session: Comicvine):
     """Test search endpoint with max_results."""
     results = session.search(resource=ComicvineResource.ISSUE, query="Lantern", max_results=10)
-    assert all(isinstance(x, Issue) for x in results)
+    assert all(isinstance(x, IssueEntry) for x in results)
     assert len(results) == 10
 
 

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,7 +1,7 @@
 """
 The Locations test module.
 
-This module contains tests for Location objects and LocationEntry objects.
+This module contains tests for Location and LocationEntry objects.
 """
 from datetime import datetime
 

--- a/tests/test_publishers.py
+++ b/tests/test_publishers.py
@@ -1,7 +1,7 @@
 """
 The Publishers test module.
 
-This module contains tests for Publisher objects.
+This module contains tests for Publisher and PublisherEntry objects.
 """
 from datetime import datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.publisher import Publisher
+from simyan.schemas.publisher import PublisherEntry
 
 
 def test_publisher(session: Comicvine):
@@ -71,16 +71,12 @@ def test_publisher_list(session: Comicvine):
         "National Comics Publications",
     ]
     assert result.api_url == "https://comicvine.gamespot.com/api/publisher/4010-10/"
-    assert result.characters == []
     assert result.date_added == datetime(2008, 6, 6, 11, 8)
     assert result.location_address == "4000 Warner Blvd"
     assert result.location_city == "Burbank"
     assert result.location_state == "California"
     assert result.name == "DC Comics"
     assert result.site_url == "https://comicvine.gamespot.com/dc-comics/4010-10/"
-    assert result.story_arcs == []
-    assert result.teams == []
-    assert result.volumes == []
 
 
 def test_publisher_list_empty(session: Comicvine):
@@ -98,11 +94,11 @@ def test_publisher_list_max_results(session: Comicvine):
 def test_search_publisher(session: Comicvine):
     """Test using the search endpoint for a list of Publishers."""
     results = session.search(resource=ComicvineResource.PUBLISHER, query="DC")
-    assert all(isinstance(x, Publisher) for x in results)
+    assert all(isinstance(x, PublisherEntry) for x in results)
 
 
 def test_search_publisher_max_results(session: Comicvine):
     """Test search endpoint with max_results."""
     results = session.search(resource=ComicvineResource.PUBLISHER, query="DC", max_results=10)
-    assert all(isinstance(x, Publisher) for x in results)
+    assert all(isinstance(x, PublisherEntry) for x in results)
     assert len(results) == 0

--- a/tests/test_story_arcs.py
+++ b/tests/test_story_arcs.py
@@ -1,7 +1,7 @@
 """
 The Story Arcs test module.
 
-This module contains tests for Story Arc objects.
+This module contains tests for StoryArc and StoryArcEntry objects.
 """
 from datetime import datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.story_arc import StoryArc
+from simyan.schemas.story_arc import StoryArcEntry
 
 
 def test_story_arc(session: Comicvine):
@@ -59,7 +59,6 @@ def test_story_arc_list(session: Comicvine):
     assert result.date_added == datetime(2008, 12, 6, 21, 29, 2)
     assert result.first_issue.id_ == 155207
     assert result.issue_count == 0
-    assert result.issues == []
     assert result.name == "Blackest Night"
     assert result.publisher.id_ == 10
     assert result.site_url == "https://comicvine.gamespot.com/blackest-night/4045-55766/"
@@ -98,7 +97,7 @@ def test_story_arc_list_null_publisher(session: Comicvine):
 def test_search_story_arc(session: Comicvine):
     """Test using the search endpoint for a list of Story Arcs."""
     results = session.search(resource=ComicvineResource.STORY_ARC, query="Blackest Night")
-    assert all(isinstance(x, StoryArc) for x in results)
+    assert all(isinstance(x, StoryArcEntry) for x in results)
 
 
 def test_search_story_arc_max_results(session: Comicvine):
@@ -106,5 +105,5 @@ def test_search_story_arc_max_results(session: Comicvine):
     results = session.search(
         resource=ComicvineResource.STORY_ARC, query="Blackest Night", max_results=10
     )
-    assert all(isinstance(x, StoryArc) for x in results)
+    assert all(isinstance(x, StoryArcEntry) for x in results)
     assert len(results) == 0

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1,7 +1,7 @@
 """
 The Teams test module.
 
-This module contains tests for Team objects.
+This module contains tests for Team and TeamEntry objects.
 """
 from datetime import datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.team import Team
+from simyan.schemas.team import TeamEntry
 
 
 def test_team(session: Comicvine):
@@ -51,20 +51,13 @@ def test_team_list(session: Comicvine):
 
     assert result.alias_list == []
     assert result.api_url == "https://comicvine.gamespot.com/api/team/4060-50163/"
-    assert result.enemies == []
-    assert result.friends == []
-    assert result.members == []
     assert result.issue_count == 0
     assert result.member_count == 17
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 45)
-    assert result.issues_disbanded_in == []
     assert result.first_issue.id_ == 119950
-    assert result.issues == []
     assert result.name == "Blue Lantern Corps"
     assert result.publisher.id_ == 10
     assert result.site_url == "https://comicvine.gamespot.com/blue-lantern-corps/4060-50163/"
-    assert result.story_arcs == []
-    assert result.volumes == []
 
 
 def test_team_list_empty(session: Comicvine):
@@ -82,11 +75,11 @@ def test_team_list_max_results(session: Comicvine):
 def test_search_team(session: Comicvine):
     """Test using the search endpoint for a list of Teams."""
     results = session.search(resource=ComicvineResource.TEAM, query="Lantern")
-    assert all(isinstance(x, Team) for x in results)
+    assert all(isinstance(x, TeamEntry) for x in results)
 
 
 def test_search_team_max_results(session: Comicvine):
     """Test search endpoint with max_results."""
     results = session.search(resource=ComicvineResource.TEAM, query="Lantern", max_results=10)
-    assert all(isinstance(x, Team) for x in results)
+    assert all(isinstance(x, TeamEntry) for x in results)
     assert len(results) == 10

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -1,7 +1,7 @@
 """
 The Volumes test module.
 
-This module contains tests for Volume objects.
+This module contains tests for Volume and VolumeEntry objects.
 """
 from datetime import datetime
 
@@ -9,7 +9,7 @@ import pytest
 
 from simyan.comicvine import Comicvine, ComicvineResource
 from simyan.exceptions import ServiceError
-from simyan.schemas.volume import Volume
+from simyan.schemas.volume import VolumeEntry
 
 
 def test_volume(session: Comicvine):
@@ -82,13 +82,13 @@ def test_volume_list_max_results(session: Comicvine):
 def test_search_volume(session: Comicvine):
     """Test using the search endpoint for a list of Volumes."""
     results = session.search(resource=ComicvineResource.VOLUME, query="Lantern")
-    assert all(isinstance(x, Volume) for x in results)
+    assert all(isinstance(x, VolumeEntry) for x in results)
 
 
 def test_search_volume_max_results(session: Comicvine):
     """Test search endpoint with max_results."""
     results = session.search(resource=ComicvineResource.VOLUME, query="Lantern", max_results=10)
-    assert all(isinstance(x, Volume) for x in results)
+    assert all(isinstance(x, VolumeEntry) for x in results)
     assert len(results) == 10
 
 

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -51,17 +51,11 @@ def test_volume_list(session: Comicvine):
 
     assert result.alias_list == []
     assert result.api_url == "https://comicvine.gamespot.com/api/volume/4050-18216/"
-    assert result.characters == []
-    assert result.concepts == []
-    assert result.creators == []
     assert result.date_added == datetime(2008, 6, 6, 11, 8, 33)
     assert result.first_issue.id_ == 111265
     assert result.issue_count == 67
-    assert result.issues == []
     assert result.last_issue.id_ == 278617
-    assert result.locations == []
     assert result.name == "Green Lantern"
-    assert result.objects == []
     assert result.publisher.id_ == 10
     assert result.site_url == "https://comicvine.gamespot.com/green-lantern/4050-18216/"
     assert result.start_year == 2005


### PR DESCRIPTION
**Breaking Changes:**
- Split classes into 2 subclasses as resource and list[resource] returns different values
- search and *_list returns Entry version of resource
- Remove id_ fields