### PR TITLE
Origin endpoint

### DIFF
--- a/docs/simyan/schemas/origin.md
+++ b/docs/simyan/schemas/origin.md
@@ -1,0 +1,5 @@
+# Origin
+
+::: simyan.schemas.origin.BaseOrigin
+::: simyan.schemas.origin.Origin
+::: simyan.schemas.origin.OriginEntry

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -64,6 +64,7 @@ nav:
       - generic_entries: simyan/schemas/generic_entries.md
       - issue: simyan/schemas/issue.md
       - location: simyan/schemas/location.md
+      - origin: simyan/schemas/origin.md
       - power: simyan/schemas/power.md
       - publisher: simyan/schemas/publisher.md
       - story_arc: simyan/schemas/story_arc.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ source = ["simyan"]
 path = "simyan/__init__.py"
 
 [tool.pytest.ini_options]
-addopts = ["--cov", "-x"]
+addopts = ["--cov"]
 
 [tool.ruff]
 fix = true

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -26,6 +26,7 @@ from simyan.schemas.concept import Concept, ConceptEntry
 from simyan.schemas.creator import Creator, CreatorEntry
 from simyan.schemas.issue import Issue, IssueEntry
 from simyan.schemas.location import Location, LocationEntry
+from simyan.schemas.origin import Origin, OriginEntry
 from simyan.schemas.power import Power, PowerEntry
 from simyan.schemas.publisher import Publisher, PublisherEntry
 from simyan.schemas.story_arc import StoryArc, StoryArcEntry
@@ -60,6 +61,8 @@ class ComicvineResource(Enum):
     """Details for the Concept resource on Comicvine."""
     POWER = (4035, "power", List[PowerEntry])
     """Details for the Power resource on Comicvine."""
+    ORIGIN = (4030, "origin", List[OriginEntry])
+    """Details for the Origin resource on Comicvine."""
 
     @property
     def resource_id(self) -> int:
@@ -1019,6 +1022,54 @@ class Comicvine:
         except ValidationError as err:
             raise ServiceError(err) from err
 
+    def get_origin(self, origin_id: int) -> Origin:
+        """
+        Request data for an Origin based on its id.
+
+        Args:
+            origin_id: The Origin id.
+
+        Returns:
+            A Origin object
+        Raises:
+            ServiceError: If there is an issue with validating the response.
+        """
+        try:
+            result = self._get_request(
+                endpoint=f"/origin/{ComicvineResource.ORIGIN.resource_id}-{origin_id}",
+            )["results"]
+            return parse_obj_as(Origin, result)
+        except ValidationError as err:
+            raise ServiceError(err) from err
+
+    def list_origins(
+        self,
+        params: Optional[Dict[str, Union[str, int]]] = None,
+        max_results: int = 500,
+    ) -> List[OriginEntry]:
+        """
+        Request data for a list of Origins.
+
+        Args:
+            params: Parameters to add to the request.
+            max_results: Limits the amount of results looked up and returned.
+
+        Returns:
+            A list of OriginEntry objects.
+
+        Raises:
+            ServiceError: If there is an issue with validating the response.
+        """
+        try:
+            results = self._retrieve_offset_results(
+                endpoint="/origins/",
+                params=params,
+                max_results=max_results,
+            )
+            return parse_obj_as(List[OriginEntry], results)
+        except ValidationError as err:
+            raise ServiceError(err) from err
+
     def search(
         self,
         resource: ComicvineResource,
@@ -1035,6 +1086,7 @@ class Comicvine:
         List[LocationEntry],
         List[ConceptEntry],
         List[PowerEntry],
+        List[OriginEntry],
     ]:
         """
         Request a list of search results filtered by provided resource.

--- a/simyan/schemas/origin.py
+++ b/simyan/schemas/origin.py
@@ -1,0 +1,51 @@
+"""
+The Origin module.
+
+This module provides the following classes:
+
+- Origin
+- OriginEntry
+"""
+__all__ = ["Origin", "OriginEntry"]
+from typing import List, Optional
+
+from pydantic import Field
+
+from simyan.schemas import BaseModel
+from simyan.schemas.generic_entries import GenericEntry
+
+
+class BaseOrigin(BaseModel):
+    r"""
+    Contains fields for all Origins.
+
+    Attributes:
+        api_url: Url to the resource in the Comicvine API.
+        name: Name/Title of the Origin.
+        origin_id: Identifier used by Comicvine.
+        site_url: Url to the resource in Comicvine.
+    """
+
+    api_url: str = Field(alias="api_detail_url")
+    name: str
+    origin_id: int = Field(alias="id")
+    site_url: str = Field(alias="site_detail_url")
+
+
+class Origin(BaseOrigin):
+    r"""
+    Extends BaseOrigin by including all the list references of a origin.
+
+    Attributes:
+        character_set: Unknown field
+        characters: List of characters with the Origin.
+        profiles: Unknown field
+    """
+
+    character_set: Optional[int] = None
+    characters: List[GenericEntry] = Field(default_factory=list)
+    profiles: List[int] = Field(default_factory=list)
+
+
+class OriginEntry(BaseOrigin):
+    """Contains all the fields available when viewing a list of Origins."""

--- a/tests/test_origins.py
+++ b/tests/test_origins.py
@@ -1,0 +1,61 @@
+"""
+The Origins test module.
+
+This module contains tests for Origin and OriginEntry objects.
+"""
+
+import pytest
+
+from simyan.comicvine import Comicvine, ComicvineResource
+from simyan.exceptions import ServiceError
+from simyan.schemas.origin import OriginEntry
+
+
+def test_origin(session: Comicvine) -> None:
+    """Test using the origin endpoint with a valid origin_id."""
+    result = session.get_origin(origin_id=1)
+    assert result is not None
+    assert result.origin_id == 1
+
+    assert result.api_url == "https://comicvine.gamespot.com/api/origin/4030-1/"
+    assert result.character_set is None
+    assert len(result.characters) == 4200
+    assert result.name == "Mutant"
+    assert result.profiles == []
+    assert result.site_url == "https://comicvine.gamespot.com/mutant/4030-1/"
+
+
+def test_origin_fail(session: Comicvine) -> None:
+    """Test using the origin endpoint with an invalid origin_id."""
+    with pytest.raises(ServiceError):
+        session.get_origin(origin_id=-1)
+
+
+def test_origin_list(session: Comicvine) -> None:
+    """Test using the list origins endpoint with a valid search query."""
+    search_results = session.list_origins({"filter": "name:Mutant"})
+    assert len(search_results) != 0
+    result = [x for x in search_results if x.origin_id == 1][0]
+    assert result is not None
+
+    assert result.api_url == "https://comicvine.gamespot.com/api/origin/4030-1/"
+    assert result.name == "Mutant"
+    assert result.site_url == "https://comicvine.gamespot.com/mutant/4030-1/"
+
+
+def test_origin_list_empty(session: Comicvine) -> None:
+    """Test using the list origins endpoint with an invalid search query."""
+    results = session.list_origins({"filter": "name:INVALID"})
+    assert len(results) == 0
+
+
+def test_origin_list_max_results(session: Comicvine) -> None:
+    """Test list origins endpoint with max results."""
+    results = session.list_origins(max_results=10)
+    assert len(results) == 10
+
+
+def test_search_origin(session: Comicvine) -> None:
+    """Test using the search endpoint for a list of Origins."""
+    results = session.search(resource=ComicvineResource.ORIGIN, query="Mutant")
+    assert all(isinstance(x, OriginEntry) for x in results)


### PR DESCRIPTION
- Add support for Origin endpoints
  - `list_origins()`
  - `get_origin()`
  - `search()`
- Pytest doesn't stop on first error