### PR TITLE
Support Py3.12

### DIFF
--- a/.github/workflows/publishing.yaml
+++ b/.github/workflows/publishing.yaml
@@ -12,13 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.11'
+          - '3.12'
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -26,6 +26,7 @@ jobs:
           - 3.9
           - '3.10'
           - '3.11'
+          - '3.12'
         os:
           - ubuntu-latest
           - macos-latest
@@ -33,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.285
+    rev: v0.0.292
     hooks:
       - id: ruff
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
+    rev: 0.7.17
     hooks:
       - id: mdformat
         additional_dependencies:
@@ -20,10 +20,8 @@ repos:
       - id: check-builtin-literals
       - id: check-case-conflict
       - id: check-docstring-first
-#      - id: check-json
       - id: check-merge-conflict
       - id: check-toml
-#      - id: check-xml
       - id: check-yaml
         args:
           - --allow-multiple-documents
@@ -40,12 +38,8 @@ repos:
       - id: trailing-whitespace
         args:
           - --markdown-linebreak-ext=md
-#      - id: pretty-format-json
-#        args:
-#          - --autofix
-#          - --indent=2
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/pappasam/toml-sort

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
     python: "3.11"
 
 mkdocs:
-  configuration: mkdocs.yml
+  configuration: mkdocs.yaml
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,19 +1,19 @@
-# .readthedocs.yaml
-# Read the Docs configuration file
+# Read the Docs configuration file for MkDocs projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-mkdocs:
-  configuration: mkdocs.yaml
-
+# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: '3.11'
+    python: "3.11"
 
-# Optionally set the version of Python and requirements required to build your docs
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
 python:
   install:
     - method: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python",
@@ -24,7 +25,7 @@ classifiers = [
   "Typing :: Typed"
 ]
 dependencies = [
-  "pydantic >= 2.2.1",
+  "pydantic >= 2.4.2",
   "ratelimit >= 2.2.1",
   "requests >= 2.31.0"
 ]
@@ -41,16 +42,16 @@ requires-python = ">= 3.8"
 
 [project.optional-dependencies]
 dev = [
-  "pre-commit >= 3.3.3"
+  "pre-commit >= 3.4.0"
 ]
 docs = [
-  "mkdocs >= 1.5.2",
-  "mkdocs-include-markdown-plugin >= 6.0.0",
-  "mkdocs-material >= 9.2.1",
-  "mkdocstrings[python] >= 0.22.0"
+  "mkdocs >= 1.5.3",
+  "mkdocs-include-markdown-plugin >= 6.0.1",
+  "mkdocs-material >= 9.4.4",
+  "mkdocstrings[python] >= 0.23.0"
 ]
 test = [
-  "pytest >= 7.4.0",
+  "pytest >= 7.4.2",
   "pytest-cov >= 4.1.0",
   "pytest-pretty >= 1.2.0"
 ]
@@ -63,7 +64,7 @@ Source = "https://github.com/Metron-Project/Simyan"
 
 [tool.black]
 line-length = 100
-target-version = ["py310", "py311", "py38", "py39"]
+target-version = ["py310", "py311", "py312", "py38", "py39"]
 
 [tool.coverage.report]
 show_missing = true
@@ -79,14 +80,15 @@ addopts = ["--cov"]
 
 [tool.ruff]
 fix = true
-format = "grouped"
 ignore = [
   "D107",
   "EXE",
   "FBT",
-  "PLR2004"
+  "PLR2004",
+  "TCH"
 ]
 line-length = 100
+output-format = "grouped"
 select = ["ALL"]
 show-fixes = true
 target-version = "py38"
@@ -109,7 +111,7 @@ classmethod-decorators = ["classmethod", "pydantic.field_validator"]
 
 [tool.ruff.per-file-ignores]
 "simyan/schemas/*.py" = ["FA100"]
-"tests/test_*.py" = ["S101", "SLF001"]
+"tests/test_*.py" = ["S101"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/simyan/__init__.py
+++ b/simyan/__init__.py
@@ -1,5 +1,5 @@
 """simyan package entry file."""
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __all__ = ["__version__", "get_cache_root"]
 
 import os

--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -12,7 +12,7 @@ import platform
 import re
 from enum import Enum
 from json import JSONDecodeError
-from typing import TYPE_CHECKING, Any, List, TypeVar
+from typing import Any, List, TypeVar
 from urllib.parse import urlencode
 
 from pydantic import TypeAdapter, ValidationError
@@ -34,9 +34,7 @@ from simyan.schemas.publisher import Publisher, PublisherEntry
 from simyan.schemas.story_arc import StoryArc, StoryArcEntry
 from simyan.schemas.team import Team, TeamEntry
 from simyan.schemas.volume import Volume, VolumeEntry
-
-if TYPE_CHECKING:
-    from simyan.sqlite_cache import SQLiteCache
+from simyan.sqlite_cache import SQLiteCache
 
 MINUTE = 60
 T = TypeVar("T")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,7 +18,7 @@ def test_unauthorized() -> None:
 def test_not_found(session: Comicvine) -> None:
     """Test a 404 Not Found raises a ServiceError."""
     with pytest.raises(ServiceError):
-        session._get_request(endpoint="/invalid")
+        session._get_request(endpoint="/invalid")  # noqa: SLF001
 
 
 def test_timeout(comicvine_api_key: str) -> None:


### PR DESCRIPTION
- Update dependencies
- Update pre-commit dependencies
- Update workflow dependencies (Closes #172)
- Add support and tests for Py3.12
- Remove `TYPE_CHECKING`
- SQLite cache `con` renamed to `connection`
- SQLite cache now uses local timezone instead of UTC