### PR TITLE
Cache rework

### DIFF
--- a/simyan/sqlite_cache.py
+++ b/simyan/sqlite_cache.py
@@ -54,6 +54,7 @@ class SQLiteCache:
                 );
                 """
             )
+            conn.commit()
 
     def select(self, query: str) -> dict[str, Any]:
         """Retrieve data from the cache database.
@@ -87,6 +88,7 @@ class SQLiteCache:
                 "INSERT INTO cache (query, response, timestamp) VALUES (?, ?, ?);",
                 (query, json.dumps(response), datetime.now(tz=timezone.utc).isoformat()),
             )
+            conn.commit()
 
     def delete(self, query: str) -> None:
         """Remove entry from the cache with the provided url.
@@ -96,6 +98,7 @@ class SQLiteCache:
         """
         with self._connect() as conn:
             conn.execute("DELETE FROM cache WHERE query = ?;", (query,))
+            conn.commit()
 
     def cleanup(self) -> None:
         """Remove all expired entries from the cache database."""
@@ -104,3 +107,4 @@ class SQLiteCache:
         expiry = datetime.now(tz=timezone.utc) - timedelta(days=self._expiry)
         with self._connect() as conn:
             conn.execute("DELETE FROM cache WHERE timestamp < ?;", (expiry.isoformat(),))
+            conn.commit()

--- a/simyan/sqlite_cache.py
+++ b/simyan/sqlite_cache.py
@@ -23,11 +23,27 @@ class SQLiteCache:
     """
 
     def __init__(self, path: Optional[Path] = None, expiry: Optional[int] = 14):
-        self.expiry = expiry
-        self.connection = sqlite3.connect(path or get_cache_root() / "cache.sqlite")
-        self.connection.row_factory = sqlite3.Row
+        self._db_path = path or (get_cache_root() / "cache.sqlite")
+        self._expiry = expiry
+        self.initialize()
 
-        self.connection.execute("CREATE TABLE IF NOT EXISTS queries (query, response, query_date);")
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queries (
+                    query TEXT NOT NULL PRIMARY KEY,
+                    response TEXT,
+                    query_date DATE
+                );
+                """
+            )
         self.cleanup()
 
     def select(self, query: str) -> dict[str, Any]:
@@ -39,17 +55,18 @@ class SQLiteCache:
         Returns:
             Empty dict or select results.
         """
-        if self.expiry:
-            expiry = datetime.now(tz=timezone.utc).astimezone().date() - timedelta(days=self.expiry)
-            cursor = self.connection.execute(
-                "SELECT * FROM queries WHERE query = ? and query_date > ?;",
-                (query, expiry.isoformat()),
-            )
-        else:
-            cursor = self.connection.execute("SELECT * FROM queries WHERE query = ?;", (query,))
-        if results := cursor.fetchone():
-            return json.loads(results["response"])
-        return {}
+        with self._connect() as conn:
+            if self._expiry:
+                expiry = datetime.now(tz=timezone.utc).astimezone().date() - timedelta(
+                    days=self._expiry
+                )
+                row = conn.execute(
+                    "SELECT * FROM queries WHERE query = ? and query_date > ?;",
+                    (query, expiry.isoformat()),
+                ).fetchone()
+            else:
+                row = conn.execute("SELECT * FROM queries WHERE query = ?;", (query,)).fetchone()
+            return json.loads(row["response"]) if row else {}
 
     def insert(self, query: str, response: dict[str, Any]) -> None:
         """Insert data into the cache database.
@@ -58,15 +75,15 @@ class SQLiteCache:
             query: Url string used as key.
             response: Response dict from url.
         """
-        self.connection.execute(
-            "INSERT INTO queries (query, response, query_date) VALUES (?, ?, ?);",
-            (
-                query,
-                json.dumps(response),
-                datetime.now(tz=timezone.utc).astimezone().date().isoformat(),
-            ),
-        )
-        self.connection.commit()
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO queries (query, response, query_date) VALUES (?, ?, ?);",
+                (
+                    query,
+                    json.dumps(response),
+                    datetime.now(tz=timezone.utc).astimezone().date().isoformat(),
+                ),
+            )
 
     def delete(self, query: str) -> None:
         """Remove entry from the cache with the provided url.
@@ -74,13 +91,13 @@ class SQLiteCache:
         Args:
           query: Url string used as key.
         """
-        self.connection.execute("DELETE FROM queries WHERE query = ?;", (query,))
-        self.connection.commit()
+        with self._connect() as conn:
+            conn.execute("DELETE FROM queries WHERE query = ?;", (query,))
 
     def cleanup(self) -> None:
         """Remove all expired entries from the cache database."""
-        if not self.expiry:
+        if not self._expiry:
             return
-        expiry = datetime.now(tz=timezone.utc).astimezone().date() - timedelta(days=self.expiry)
-        self.connection.execute("DELETE FROM queries WHERE query_date < ?;", (expiry.isoformat(),))
-        self.connection.commit()
+        expiry = datetime.now(tz=timezone.utc).astimezone().date() - timedelta(days=self._expiry)
+        with self._connect() as conn:
+            conn.execute("DELETE FROM queries WHERE query_date < ?;", (expiry.isoformat(),))

--- a/tests/characters_test.py
+++ b/tests/characters_test.py
@@ -23,8 +23,8 @@ def test_get_character(session: Comicvine) -> None:
     assert len(result.enemies) == 150
     assert len(result.enemy_teams) == 25
     assert len(result.friendly_teams) == 17
-    assert len(result.friends) == 233
-    assert len(result.issues) == 1714
+    assert len(result.friends) == 232
+    assert len(result.issues) == 1731
     assert len(result.powers) == 28
     assert len(result.story_arcs) == 0
     assert len(result.teams) == 21
@@ -49,7 +49,7 @@ def test_list_characters(session: Comicvine) -> None:
     assert result.date_of_birth is None
     assert result.first_issue.id == 38445
     assert result.gender == 1
-    assert result.issue_count == 1714
+    assert result.issue_count == 1731
     assert result.name == "Kyle Rayner"
     assert result.origin.id == 4
     assert result.publisher.id == 10

--- a/tests/characters_test.py
+++ b/tests/characters_test.py
@@ -24,7 +24,7 @@ def test_get_character(session: Comicvine) -> None:
     assert len(result.enemy_teams) == 25
     assert len(result.friendly_teams) == 17
     assert len(result.friends) == 232
-    assert len(result.issues) == 1731
+    assert len(result.issues) == 1732
     assert len(result.powers) == 28
     assert len(result.story_arcs) == 0
     assert len(result.teams) == 21
@@ -49,7 +49,7 @@ def test_list_characters(session: Comicvine) -> None:
     assert result.date_of_birth is None
     assert result.first_issue.id == 38445
     assert result.gender == 1
-    assert result.issue_count == 1731
+    assert result.issue_count == 1732
     assert result.name == "Kyle Rayner"
     assert result.origin.id == 4
     assert result.publisher.id == 10

--- a/tests/concepts_test.py
+++ b/tests/concepts_test.py
@@ -18,7 +18,7 @@ def test_get_concept(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 41148
 
-    assert len(result.issues) == 2589
+    assert len(result.issues) == 2652
     assert len(result.volumes) == 1
 
 
@@ -38,7 +38,7 @@ def test_list_concepts(session: Comicvine) -> None:
     assert str(result.api_url) == "https://comicvine.gamespot.com/api/concept/4015-41148/"
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 52)
     assert result.first_issue.id == 144069
-    assert result.issue_count == 2589
+    assert result.issue_count == 2652
     assert result.name == "Green Lantern"
     assert str(result.site_url) == "https://comicvine.gamespot.com/green-lantern/4015-41148/"
     assert result.start_year == 1940

--- a/tests/concepts_test.py
+++ b/tests/concepts_test.py
@@ -18,7 +18,7 @@ def test_get_concept(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 41148
 
-    assert len(result.issues) == 2652
+    assert len(result.issues) == 2653
     assert len(result.volumes) == 1
 
 
@@ -38,7 +38,7 @@ def test_list_concepts(session: Comicvine) -> None:
     assert str(result.api_url) == "https://comicvine.gamespot.com/api/concept/4015-41148/"
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 52)
     assert result.first_issue.id == 144069
-    assert result.issue_count == 2652
+    assert result.issue_count == 2653
     assert result.name == "Green Lantern"
     assert str(result.site_url) == "https://comicvine.gamespot.com/green-lantern/4015-41148/"
     assert result.start_year == 1940

--- a/tests/creators_test.py
+++ b/tests/creators_test.py
@@ -18,10 +18,10 @@ def test_get_creator(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 40439
 
-    assert len(result.characters) == 309
-    assert len(result.issues) == 1608
-    assert len(result.story_arcs) == 23
-    assert len(result.volumes) == 595
+    assert len(result.characters) == 320
+    assert len(result.issues) == 1640
+    assert len(result.story_arcs) == 27
+    assert len(result.volumes) == 604
 
 
 def test_get_creator_fail(session: Comicvine) -> None:

--- a/tests/items_test.py
+++ b/tests/items_test.py
@@ -18,9 +18,9 @@ def test_get_item(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 41361
 
-    assert len(result.issues) == 3335
+    assert len(result.issues) == 3336
     assert len(result.story_arcs) == 457
-    assert len(result.volumes) == 1006
+    assert len(result.volumes) == 1007
 
 
 def test_get_item_fail(session: Comicvine) -> None:
@@ -39,7 +39,7 @@ def test_list_items(session: Comicvine) -> None:
     assert str(result.api_url) == "https://comicvine.gamespot.com/api/object/4055-41361/"
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 50)
     assert result.first_issue.id == 123898
-    assert result.issue_count == 3335
+    assert result.issue_count == 3336
     assert result.name == "Green Power Ring"
     assert str(result.site_url) == "https://comicvine.gamespot.com/green-power-ring/4055-41361/"
     assert result.start_year == 1940

--- a/tests/items_test.py
+++ b/tests/items_test.py
@@ -18,9 +18,9 @@ def test_get_item(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 41361
 
-    assert len(result.issues) == 3308
-    assert len(result.story_arcs) == 454
-    assert len(result.volumes) == 993
+    assert len(result.issues) == 3335
+    assert len(result.story_arcs) == 457
+    assert len(result.volumes) == 1006
 
 
 def test_get_item_fail(session: Comicvine) -> None:
@@ -39,7 +39,7 @@ def test_list_items(session: Comicvine) -> None:
     assert str(result.api_url) == "https://comicvine.gamespot.com/api/object/4055-41361/"
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 50)
     assert result.first_issue.id == 123898
-    assert result.issue_count == 3308
+    assert result.issue_count == 3335
     assert result.name == "Green Power Ring"
     assert str(result.site_url) == "https://comicvine.gamespot.com/green-power-ring/4055-41361/"
     assert result.start_year == 1940

--- a/tests/origins_test.py
+++ b/tests/origins_test.py
@@ -17,7 +17,7 @@ def test_get_origin(session: Comicvine) -> None:
     assert result.id == 1
 
     assert result.character_set is None
-    assert len(result.characters) == 4477
+    assert len(result.characters) == 4480
     assert len(result.profiles) == 0
 
 

--- a/tests/origins_test.py
+++ b/tests/origins_test.py
@@ -17,7 +17,7 @@ def test_get_origin(session: Comicvine) -> None:
     assert result.id == 1
 
     assert result.character_set is None
-    assert len(result.characters) == 4399
+    assert len(result.characters) == 4477
     assert len(result.profiles) == 0
 
 

--- a/tests/powers_test.py
+++ b/tests/powers_test.py
@@ -18,7 +18,7 @@ def test_get_power(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 1
 
-    assert len(result.characters) == 8365
+    assert len(result.characters) == 8367
 
 
 def test_get_power_fail(session: Comicvine) -> None:

--- a/tests/powers_test.py
+++ b/tests/powers_test.py
@@ -18,7 +18,7 @@ def test_get_power(session: Comicvine) -> None:
     assert result is not None
     assert result.id == 1
 
-    assert len(result.characters) == 8310
+    assert len(result.characters) == 8365
 
 
 def test_get_power_fail(session: Comicvine) -> None:

--- a/tests/publishers_test.py
+++ b/tests/publishers_test.py
@@ -14,14 +14,14 @@ from simyan.schemas.publisher import BasicPublisher
 
 def test_get_publisher(session: Comicvine) -> None:
     """Test the get_publisher function with a valid id."""
-    result = session.get_publisher(publisher_id=10)
+    result = session.get_publisher(publisher_id=364)
     assert result is not None
-    assert result.id == 10
+    assert result.id == 364
 
-    assert len(result.characters) == 24149
-    assert len(result.story_arcs) == 895
-    assert len(result.teams) == 1869
-    assert len(result.volumes) == 9416
+    assert len(result.characters) == 775
+    assert len(result.story_arcs) == 38
+    assert len(result.teams) == 42
+    assert len(result.volumes) == 4693
 
 
 def test_get_publisher_fail(session: Comicvine) -> None:

--- a/tests/publishers_test.py
+++ b/tests/publishers_test.py
@@ -21,7 +21,7 @@ def test_get_publisher(session: Comicvine) -> None:
     assert len(result.characters) == 775
     assert len(result.story_arcs) == 38
     assert len(result.teams) == 42
-    assert len(result.volumes) == 4693
+    assert len(result.volumes) == 4692
 
 
 def test_get_publisher_fail(session: Comicvine) -> None:

--- a/tests/teams_test.py
+++ b/tests/teams_test.py
@@ -22,7 +22,7 @@ def test_get_team(session: Comicvine) -> None:
     assert len(result.friends) == 10
     assert len(result.issues) == 120
     assert len(result.issues_disbanded_in) == 1
-    assert len(result.members) == 18
+    assert len(result.members) == 19
     assert len(result.story_arcs) == 0
     assert len(result.volumes) == 65
 
@@ -42,7 +42,7 @@ def test_list_teams(session: Comicvine) -> None:
 
     assert str(result.api_url) == "https://comicvine.gamespot.com/api/team/4060-50163/"
     assert result.issue_count == 0
-    assert result.member_count == 18
+    assert result.member_count == 19
     assert result.date_added == datetime(2008, 6, 6, 11, 27, 45)
     assert result.first_issue.id == 119950
     assert result.name == "Blue Lantern Corps"

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -19,7 +19,7 @@ def test_get_volume(session: Comicvine) -> None:
     assert result.id == 18216
 
     assert len(result.characters) == 368
-    assert len(result.concepts) == 19
+    assert len(result.concepts) == 10
     assert len(result.creators) == 95
     assert len(result.issues) == 67
     assert len(result.locations) == 48


### PR DESCRIPTION
- Refactor `SQLiteCache` so internally it uses a contextmanager to ensure connections are opened and closed
- Refresh cache
- Cached cache table name and column typings, this will cause existing caches to be invalid