### PR TITLE
Allow user to set user_agent string

### DIFF
--- a/simyan/comicvine.py
+++ b/simyan/comicvine.py
@@ -109,6 +109,7 @@ class Comicvine:
         api_key: User's API key to access the Comicvine API.
         timeout: Set how long requests will wait for a response (in seconds).
         cache: SQLiteCache to use if set.
+        user_agent: Custom User-Agent string. If None, uses default Simyan User-Agent.
     """
 
     API_URL = "https://comicvine.gamespot.com/api"
@@ -121,10 +122,17 @@ class Comicvine:
     _limiter = Limiter(_bucket, raise_when_fail=False, max_delay=Duration.DAY)
     decorator = _limiter.as_decorator()
 
-    def __init__(self, api_key: str, timeout: int = 30, cache: SQLiteCache | None = None):
+    def __init__(
+        self,
+        api_key: str,
+        timeout: int = 30,
+        cache: SQLiteCache | None = None,
+        user_agent: str | None = None,
+    ):
         self.headers = {
             "Accept": "application/json",
-            "User-Agent": f"Simyan/{__version__}/{platform.system()}: {platform.release()}",
+            "User-Agent": user_agent
+            or f"Simyan/{__version__}/{platform.system()}: {platform.release()}",
         }
         self.api_key = api_key
         self.timeout = timeout

--- a/tests/comicvine_test.py
+++ b/tests/comicvine_test.py
@@ -1,0 +1,47 @@
+"""The Comicvine test module.
+
+This module contains tests for the Comicvine class initialization and configuration.
+"""
+
+import platform
+
+from simyan import __version__
+from simyan.comicvine import Comicvine
+
+
+def test_default_user_agent(comicvine_api_key: str) -> None:
+    """Test that the default User-Agent is set correctly."""
+    session = Comicvine(api_key=comicvine_api_key)
+    expected_user_agent = f"Simyan/{__version__}/{platform.system()}: {platform.release()}"
+    assert session.headers["User-Agent"] == expected_user_agent
+
+
+def test_custom_user_agent(comicvine_api_key: str) -> None:
+    """Test that a custom User-Agent can be set."""
+    custom_ua = "MyCustomApp/1.0"
+    session = Comicvine(api_key=comicvine_api_key, user_agent=custom_ua)
+    assert session.headers["User-Agent"] == custom_ua
+
+
+def test_custom_user_agent_with_all_params(comicvine_api_key: str) -> None:
+    """Test that custom User-Agent works with all initialization parameters."""
+    custom_ua = "TestApp/2.0 (Custom)"
+    session = Comicvine(api_key=comicvine_api_key, timeout=60, cache=None, user_agent=custom_ua)
+    assert session.headers["User-Agent"] == custom_ua
+    assert session.timeout == 60
+    assert session.cache is None
+
+
+def test_empty_string_user_agent_uses_default(comicvine_api_key: str) -> None:
+    """Test that an empty string User-Agent falls back to default."""
+    session = Comicvine(api_key=comicvine_api_key, user_agent="")
+    expected_user_agent = f"Simyan/{__version__}/{platform.system()}: {platform.release()}"
+    assert session.headers["User-Agent"] == expected_user_agent
+
+
+def test_headers_structure(comicvine_api_key: str) -> None:
+    """Test that headers are properly structured."""
+    session = Comicvine(api_key=comicvine_api_key)
+    assert "Accept" in session.headers
+    assert "User-Agent" in session.headers
+    assert session.headers["Accept"] == "application/json"


### PR DESCRIPTION
~~This should fix CV support in the short term since they have apparently whitelisted the `Comictagger` user-agent.~~
Turns out Barda doesn't need this change, tho I might be worthwhile to have, your choice if you want it or not.